### PR TITLE
Add some tick keys

### DIFF
--- a/graph_objs/julia/graph_objs_keymeta.json
+++ b/graph_objs/julia/graph_objs_keymeta.json
@@ -2100,17 +2100,41 @@
             "required": false, 
             "description": "Links a dictionary defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
         }, 
         "x": {
             "key_type": "plot_info", 
@@ -2437,17 +2461,53 @@
             "required": false, 
             "description": "Links a dictionary defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -2713,17 +2773,53 @@
             "required": false, 
             "description": "Links a dictionary defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -3187,17 +3283,53 @@
             "required": false, 
             "description": "Links a dictionary defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 

--- a/graph_objs/julia/graph_objs_meta.json
+++ b/graph_objs/julia/graph_objs_meta.json
@@ -2307,17 +2307,41 @@
                 "required": false, 
                 "description": "Links a dictionary defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
             }, 
             "x": {
                 "key_type": "plot_info", 
@@ -2681,17 +2705,53 @@
                 "required": false, 
                 "description": "Links a dictionary defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -2972,17 +3032,53 @@
                 "required": false, 
                 "description": "Links a dictionary defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -3490,17 +3586,53 @@
                 "required": false, 
                 "description": "Links a dictionary defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 

--- a/graph_objs/matlab/graph_objs_keymeta.json
+++ b/graph_objs/matlab/graph_objs_keymeta.json
@@ -2100,17 +2100,41 @@
             "required": false, 
             "description": "Links a structure array defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
         }, 
         "x": {
             "key_type": "plot_info", 
@@ -2437,17 +2461,53 @@
             "required": false, 
             "description": "Links a structure array defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -2713,17 +2773,53 @@
             "required": false, 
             "description": "Links a structure array defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -3189,17 +3285,53 @@
             "required": false, 
             "description": "Links a structure array defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 

--- a/graph_objs/matlab/graph_objs_meta.json
+++ b/graph_objs/matlab/graph_objs_meta.json
@@ -2307,17 +2307,41 @@
                 "required": false, 
                 "description": "Links a structure array defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
             }, 
             "x": {
                 "key_type": "plot_info", 
@@ -2681,17 +2705,53 @@
                 "required": false, 
                 "description": "Links a structure array defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -2972,17 +3032,53 @@
                 "required": false, 
                 "description": "Links a structure array defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -3492,17 +3588,53 @@
                 "required": false, 
                 "description": "Links a structure array defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 

--- a/graph_objs/nodejs/graph_objs_keymeta.json
+++ b/graph_objs/nodejs/graph_objs_keymeta.json
@@ -2100,17 +2100,41 @@
             "required": false, 
             "description": "Links an object defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
         }, 
         "x": {
             "key_type": "plot_info", 
@@ -2437,17 +2461,53 @@
             "required": false, 
             "description": "Links an object defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -2713,17 +2773,53 @@
             "required": false, 
             "description": "Links an object defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -3187,17 +3283,53 @@
             "required": false, 
             "description": "Links an object defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 

--- a/graph_objs/nodejs/graph_objs_meta.json
+++ b/graph_objs/nodejs/graph_objs_meta.json
@@ -2307,17 +2307,41 @@
                 "required": false, 
                 "description": "Links an object defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
             }, 
             "x": {
                 "key_type": "plot_info", 
@@ -2681,17 +2705,53 @@
                 "required": false, 
                 "description": "Links an object defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -2972,17 +3032,53 @@
                 "required": false, 
                 "description": "Links an object defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -3490,17 +3586,53 @@
                 "required": false, 
                 "description": "Links an object defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 

--- a/graph_objs/python/graph_objs_keymeta.json
+++ b/graph_objs/python/graph_objs_keymeta.json
@@ -2100,17 +2100,41 @@
             "required": false, 
             "description": "Links a dictionary-like object defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
         }, 
         "x": {
             "key_type": "plot_info", 
@@ -2437,17 +2461,53 @@
             "required": false, 
             "description": "Links a dictionary-like object defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -2713,17 +2773,53 @@
             "required": false, 
             "description": "Links a dictionary-like object defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -3190,17 +3286,53 @@
             "required": false, 
             "description": "Links a dictionary-like object defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 

--- a/graph_objs/python/graph_objs_meta.json
+++ b/graph_objs/python/graph_objs_meta.json
@@ -2334,17 +2334,41 @@
                 "required": false, 
                 "description": "Links a dictionary-like object defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
             }, 
             "x": {
                 "key_type": "plot_info", 
@@ -2708,17 +2732,53 @@
                 "required": false, 
                 "description": "Links a dictionary-like object defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -2999,17 +3059,53 @@
                 "required": false, 
                 "description": "Links a dictionary-like object defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -3520,17 +3616,53 @@
                 "required": false, 
                 "description": "Links a dictionary-like object defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 

--- a/graph_objs/r/graph_objs_keymeta.json
+++ b/graph_objs/r/graph_objs_keymeta.json
@@ -2100,17 +2100,41 @@
             "required": false, 
             "description": "Links a list defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
         }, 
         "x": {
             "key_type": "plot_info", 
@@ -2437,17 +2461,53 @@
             "required": false, 
             "description": "Links a list defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -2713,17 +2773,53 @@
             "required": false, 
             "description": "Links a list defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 
@@ -3187,17 +3283,53 @@
             "required": false, 
             "description": "Links a list defining the parameters of the ticks' font."
         }, 
+        "showexponent": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+        }, 
         "exponentformat": {
             "key_type": "style", 
             "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
             "required": false, 
             "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
         }, 
-        "showexponent": {
+        "showtickprefix": {
             "key_type": "style", 
             "val_types": "'all' | 'first' | 'last' | 'none'", 
             "required": false, 
-            "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            "description": "Same as 'showexponent' but for tick prefixes."
+        }, 
+        "tickprefix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick prefix."
+        }, 
+        "showticksuffix": {
+            "key_type": "style", 
+            "val_types": "'all' | 'first' | 'last' | 'none'", 
+            "required": false, 
+            "description": "Same as 'showexponent' but for tick suffixes."
+        }, 
+        "ticksuffix": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Tick suffix."
+        }, 
+        "tickformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom tick datetime formatting."
+        }, 
+        "hoverformat": {
+            "key_type": "style", 
+            "val_types": "a string", 
+            "required": false, 
+            "description": "Custom hover datetime formatting."
         }, 
         "mirror": {
             "key_type": "style", 

--- a/graph_objs/r/graph_objs_meta.json
+++ b/graph_objs/r/graph_objs_meta.json
@@ -2307,17 +2307,41 @@
                 "required": false, 
                 "description": "Links a list defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
             }, 
             "x": {
                 "key_type": "plot_info", 
@@ -2681,17 +2705,53 @@
                 "required": false, 
                 "description": "Links a list defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -2972,17 +3032,53 @@
                 "required": false, 
                 "description": "Links a list defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 
@@ -3490,17 +3586,53 @@
                 "required": false, 
                 "description": "Links a list defining the parameters of the ticks' font."
             }, 
+            "showexponent": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+            }, 
             "exponentformat": {
                 "key_type": "style", 
                 "val_types": "'none' | 'e' | 'E' | 'power' | 'SI' | 'B'", 
                 "required": false, 
                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency)."
             }, 
-            "showexponent": {
+            "showtickprefix": {
                 "key_type": "style", 
                 "val_types": "'all' | 'first' | 'last' | 'none'", 
                 "required": false, 
-                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands."
+                "description": "Same as 'showexponent' but for tick prefixes."
+            }, 
+            "tickprefix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick prefix."
+            }, 
+            "showticksuffix": {
+                "key_type": "style", 
+                "val_types": "'all' | 'first' | 'last' | 'none'", 
+                "required": false, 
+                "description": "Same as 'showexponent' but for tick suffixes."
+            }, 
+            "ticksuffix": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Tick suffix."
+            }, 
+            "tickformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom tick datetime formatting."
+            }, 
+            "hoverformat": {
+                "key_type": "style", 
+                "val_types": "a string", 
+                "required": false, 
+                "description": "Custom hover datetime formatting."
             }, 
             "mirror": {
                 "key_type": "style", 

--- a/published/julia/config.json
+++ b/published/julia/config.json
@@ -3111,6 +3111,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3119,11 +3127,35 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3616,6 +3648,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3624,11 +3664,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3995,6 +4075,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4003,11 +4091,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -4682,6 +4810,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4690,11 +4826,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {

--- a/published/matlab/config.json
+++ b/published/matlab/config.json
@@ -3111,6 +3111,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3119,11 +3127,35 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3616,6 +3648,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3624,11 +3664,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3995,6 +4075,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4003,11 +4091,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -4684,6 +4812,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4692,11 +4828,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {

--- a/published/nodejs/config.json
+++ b/published/nodejs/config.json
@@ -3111,6 +3111,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3119,11 +3127,35 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3616,6 +3648,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3624,11 +3664,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3995,6 +4075,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4003,11 +4091,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -4682,6 +4810,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4690,11 +4826,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {

--- a/published/python/config.json
+++ b/published/python/config.json
@@ -3138,6 +3138,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3146,11 +3154,35 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3643,6 +3675,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3651,11 +3691,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -4022,6 +4102,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4030,11 +4118,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -4712,6 +4840,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4720,11 +4856,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {

--- a/published/r/config.json
+++ b/published/r/config.json
@@ -3111,6 +3111,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3119,11 +3127,35 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3616,6 +3648,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -3624,11 +3664,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -3995,6 +4075,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4003,11 +4091,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {
@@ -4682,6 +4810,14 @@
                             }
                         }, 
                         {
+                            "showexponent": {
+                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
                             "exponentformat": {
                                 "description": "Sets how exponents show up. Here's how the number 1000000000 (1 billion) shows up in each. If set to 'none': 1,000,000,000. If set to 'e': 1e+9. If set to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 will appear super-scripted). If set to 'SI': 1G. If set to 'B': 1B (useful when referring to currency).", 
                                 "key_type": "style", 
@@ -4690,11 +4826,51 @@
                             }
                         }, 
                         {
-                            "showexponent": {
-                                "description": "If set to 'all', ALL exponents will be shown appended to their significands. If set to 'first', the first tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'last', the last tick's exponent will be appended to its significand, however no other exponents will appear--only the significands. If set to 'none', no exponents will appear, only the significands.", 
+                            "showtickprefix": {
+                                "description": "Same as 'showexponent' but for tick prefixes.", 
                                 "key_type": "style", 
                                 "required": false, 
                                 "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "tickprefix": {
+                                "description": "Tick prefix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "showticksuffix": {
+                                "description": "Same as 'showexponent' but for tick suffixes.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "'all' | 'first' | 'last' | 'none'"
+                            }
+                        }, 
+                        {
+                            "ticksuffix": {
+                                "description": "Tick suffix.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "tickformat": {
+                                "description": "Custom tick datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
+                            }
+                        }, 
+                        {
+                            "hoverformat": {
+                                "description": "Custom hover datetime formatting.", 
+                                "key_type": "style", 
+                                "required": false, 
+                                "val_types": "a string"
                             }
                         }, 
                         {

--- a/scripts/meta.py
+++ b/scripts/meta.py
@@ -1135,19 +1135,6 @@ class MakeMeta(list):
                     "of the ticks' font."
                 )
             )),
-            ('exponentformat', dict(
-                required=False,
-                key_type='style',
-                val_types="'none' | 'e' | 'E' | 'power' | 'SI' | 'B'",
-                description=(
-                    "Sets how exponents show up. Here's how the number "
-                    "1000000000 (1 billion) shows up in each. If set to "
-                    "'none': 1,000,000,000. If set to 'e': 1e+9. If set "
-                    "to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 "
-                    "will appear super-scripted). If set to 'SI': 1G. If "
-                    "set to 'B': 1B (useful when referring to currency)."
-                )
-            )),
             ('showexponent', dict(
                 required=False,
                 key_type='style',
@@ -1162,6 +1149,51 @@ class MakeMeta(list):
                     "significand, however no other exponents will "
                     "appear--only the significands. If set to 'none', "
                     "no exponents will appear, only the significands."
+                )
+            )),
+            ('exponentformat', dict(
+                required=False,
+                key_type='style',
+                val_types="'none' | 'e' | 'E' | 'power' | 'SI' | 'B'",
+                description=(
+                    "Sets how exponents show up. Here's how the number "
+                    "1000000000 (1 billion) shows up in each. If set to "
+                    "'none': 1,000,000,000. If set to 'e': 1e+9. If set "
+                    "to 'E': 1E+9. If set to 'power': 1x10^9 (where the 9 "
+                    "will appear super-scripted). If set to 'SI': 1G. If "
+                    "set to 'B': 1B (useful when referring to currency)."
+                )
+            )),
+            ('showtickprefix', dict(
+                required=False,
+                key_type='style',
+                val_types="'all' | 'first' | 'last' | 'none'",
+                description=(
+                    "Same as 'showexponent' but for tick prefixes."
+                )
+            )),
+            ('tickprefix', dict(
+                required=False,
+                key_type='style',
+                val_types=val_types.string(),
+                description=(
+                    "Tick prefix."
+                )
+            )),
+            ('showticksuffix', dict(
+                required=False,
+                key_type='style',
+                val_types="'all' | 'first' | 'last' | 'none'",
+                description=(
+                    "Same as 'showexponent' but for tick suffixes."
+                )
+            )),
+            ('ticksuffix', dict(
+                required=False,
+                key_type='style',
+                val_types=val_types.string(),
+                description=(
+                    "Tick suffix."
                 )
             ))
         ]
@@ -1242,6 +1274,22 @@ class MakeMeta(list):
         ]
         _keymeta += self._keymeta_ticks('axis')
         _keymeta += [
+            ('tickformat', dict(
+                required=False,
+                key_type='style',
+                val_types=val_types.string(),
+                description=(
+                    "Custom tick datetime formatting."
+                )
+            )),
+            ('hoverformat', dict(
+                required=False,
+                key_type='style',
+                val_types=val_types.string(),
+                description=(
+                    "Custom hover datetime formatting."
+                )
+            )),
             ('mirror', dict(
                 required=False,
                 key_type='style',


### PR DESCRIPTION
A user wrote in about `tickformat` not being in the python api ...

@chriddyp @theengineear 